### PR TITLE
fix mmap error type

### DIFF
--- a/db.go
+++ b/db.go
@@ -280,7 +280,7 @@ func (db *DB) mmap(minsz int) error {
 		if err2 := mmap(db, db.datasz); err2 != nil {
 			panic(fmt.Sprintf("failed to revert db size after failed mmap: %v", err2))
 		}
-		return MmapError(err)
+		return MmapError(err.Error())
 	}
 
 	// Save references to the meta pages.

--- a/errors.go
+++ b/errors.go
@@ -73,4 +73,6 @@ var (
 // MmapError represents an error resulting from a failed mmap call. Typically,
 // this error means that no further database writes will be possible. The most
 // common cause is insufficient disk space.
-type MmapError error
+type MmapError string
+
+func (e MmapError) Error() string { return string(e) }


### PR DESCRIPTION
Previously `MmapError` was useless because a type assertion for it would also return true for any other error type. That is,
```go
if _, ok := err.(bolt.MmapError); ok {

}
```
would result in `ok == true` even if the error didn't result from an mmap failure. :disappointed: 