### PR TITLE
add tx.FlushDBPages method

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ package main
 import (
 	"log"
 
-	"github.com/boltdb/bolt"
+	"github.com/NebulousLabs/bolt"
 )
 
 func main() {

--- a/bucket_test.go
+++ b/bucket_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"testing/quick"
 
-	"github.com/boltdb/bolt"
+	"github.com/NebulousLabs/bolt"
 )
 
 // Ensure that a bucket that gets a non-existent key returns nil.

--- a/cmd/bolt/main.go
+++ b/cmd/bolt/main.go
@@ -19,7 +19,7 @@ import (
 	"unicode/utf8"
 	"unsafe"
 
-	"github.com/boltdb/bolt"
+	"github.com/NebulousLabs/bolt"
 )
 
 var (

--- a/cmd/bolt/main_test.go
+++ b/cmd/bolt/main_test.go
@@ -12,8 +12,8 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/boltdb/bolt"
-	"github.com/boltdb/bolt/cmd/bolt"
+	"github.com/NebulousLabs/bolt"
+	"github.com/NebulousLabs/bolt/cmd/bolt"
 )
 
 // Ensure the "info" command can print information about a database.

--- a/cursor_test.go
+++ b/cursor_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"testing/quick"
 
-	"github.com/boltdb/bolt"
+	"github.com/NebulousLabs/bolt"
 )
 
 // Ensure that a cursor can return a reference to the bucket that created it.

--- a/db_test.go
+++ b/db_test.go
@@ -19,7 +19,7 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/boltdb/bolt"
+	"github.com/NebulousLabs/bolt"
 )
 
 var statsFlag = flag.Bool("stats", false, "show performance stats")

--- a/simulation_test.go
+++ b/simulation_test.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/boltdb/bolt"
+	"github.com/NebulousLabs/bolt"
 )
 
 func TestSimulate_1op_1p(t *testing.T)     { testSimulate(t, 1, 1) }

--- a/tx.go
+++ b/tx.go
@@ -364,6 +364,18 @@ func (tx *Tx) CopyFile(path string, mode os.FileMode) error {
 	return f.Close()
 }
 
+// FlushDBPages unmaps and re-mmaps the db file, flushing all of the DB's
+// pages from resident memory. It returns an error if called from a read-only
+// transaction.
+func (tx *Tx) FlushDBPages() error {
+	if tx.db == nil {
+		return ErrTxClosed
+	} else if !tx.writable {
+		return ErrTxNotWritable
+	}
+	return tx.db.mmap(tx.db.datasz)
+}
+
 // Check performs several consistency checks on the database for this transaction.
 // An error is returned if any inconsistency is found.
 //

--- a/tx_test.go
+++ b/tx_test.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/boltdb/bolt"
+	"github.com/NebulousLabs/bolt"
 )
 
 // Ensure that committing a closed transaction returns an error.

--- a/tx_test.go
+++ b/tx_test.go
@@ -527,6 +527,63 @@ func TestTx_CopyFile(t *testing.T) {
 	}
 }
 
+// Ensure that the database can flush pages during normal operation without
+// crashing.
+func TestTx_FlushDBPages(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucket([]byte("widgets"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := b.Put([]byte("foo"), []byte("bar")); err != nil {
+			t.Fatal(err)
+		}
+		if err := b.Put([]byte("baz"), []byte("bat")); err != nil {
+			t.Fatal(err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		return tx.FlushDBPages()
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Flush concurrently with a read and write
+	errs := make(chan error)
+	go func() {
+		errs <- db.Update(func(tx *bolt.Tx) error {
+			return tx.FlushDBPages()
+		})
+	}()
+	go func() {
+		errs <- db.Update(func(tx *bolt.Tx) error {
+			return tx.Bucket([]byte("widgets")).Put([]byte("foo"), []byte("quux"))
+		})
+	}()
+	go func() {
+		errs <- db.View(func(tx *bolt.Tx) error {
+			_ = tx.Bucket([]byte("widgets")).Get([]byte("foo"))
+			return nil
+		})
+	}()
+	for i := 0; i < 3; i++ {
+		if err := <-errs; err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 type failWriterError struct{}
 
 func (failWriterError) Error() string {


### PR DESCRIPTION
This method flushes pages from RES, reducing (perceived) memory scarcity.
I tested this by adding the following code to Sia's consensus set:
```go
go func() {
	for range time.Tick(10 * time.Second) {
		cs.db.Update(func(tx *bolt.Tx) error {
			return tx.FlushDBPages()
		})
	}
}()
```
The result was, during rescan (specifically, rescanning a renter from height 0) memory usage steadily grew to about 1 GB RES, then dropped to about 200 MB RES once the rescan finished. Once this is merged, we can figure out how to best add intermittent flushing to the various Sia bolt dbs. For example, in the wallet and tpool where we already coalesce transactions with `syncDB`, we could also flush all pages there.